### PR TITLE
Add instructions about installation from AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ curl -OL https://github.com/nakabonne/ali/releases/download/v0.1.2/ali_0.1.2_lin
 rpm -i ./ali_0.1.2_linux_amd64.rpm
 ```
 
+**Via AUR**
+
+```bash
+yay -S ali
+```
+
 **Via Go**
 
 ```bash


### PR DESCRIPTION
Hi,
I'm an [Arch Linux](https://aur.archlinux.org) package [maintainer](https://github.com/orhun/PKGBUILDs). I'm submitting this PR to let you know that I created the following packages for the installation of `ali` on Arch Linux and other distributions that support installing packages from [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository):

* [ali](https://aur.archlinux.org/packages/ali/) (builds from source)
* [ali-bin](https://aur.archlinux.org/packages/ali-bin/) (latest binary)
* [ali-git](https://aur.archlinux.org/packages/ali-git/) (VCS/development package)

I also updated README.md about installation from AUR. (eb056fe)

BR,
orhun.