### PR TITLE
Remove goreport badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![codecov.io Code Coverage](https://img.shields.io/codecov/c/github/nakabonne/ali.svg?maxAge=2592000)](https://codecov.io/github/nakabonne/ali?branch=master)
 [![Release](https://img.shields.io/github/release/nakabonne/ali.svg?color=orange)](https://github.com/nakabonne/ali/releases/latest)
 [![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/nakabonne/ali)
-[![Go Report Card](https://goreportcard.com/badge/github.com/nakabonne/ali)](https://goreportcard.com/report/github.com/nakabonne/ali)
 
 A load testing tool aimed to perform real-time analysis, inspired by [vegeta](https://github.com/tsenart/vegeta) and [jplot](https://github.com/rs/jplot).
 


### PR DESCRIPTION
Recently, https://goreportcard.com looks unstable.