### PR TITLE
Fix brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Binary releases are available through [here](https://github.com/nakabonne/ali/re
 **Via Homebrew**
 
 ```bash
-brew install nakabonne/ali/ali
+brew tap nakabonne/ali
+brew install ali
 ```
 
 **Via APT**


### PR DESCRIPTION
Docs suggest `brew install nakabonne/ali/ali` however Homebrew responds with an error, I believe the correct series of commands is `brew tap nakabonne/ali` followed by `brew install ali`

```
brew install nakabonne/ali/ali
==> Tapping nakabonne/ali
Cloning into '/usr/local/Homebrew/Library/Taps/nakabonne/homebrew-ali'...
Error: No available formula or cask with the name "nakabonne/ali/ali".
==> Searching for similarly named formulae...
This similarly named formula was found:
ali
To install it, run:
  brew install ali
brew install ali
==> Installing ali from nakabonne/ali
```