### PR TITLE
change timestamp format to not have millis/nanos at all

### DIFF
--- a/gui/drawer.go
+++ b/gui/drawer.go
@@ -137,9 +137,9 @@ func (d *drawer) redrawMetrics(ctx context.Context) {
 				metrics.Rate,
 				metrics.Throughput,
 				metrics.Success,
-				metrics.Earliest,
-				metrics.Latest,
-				metrics.End,
+				metrics.Earliest.Format(time.RFC3339),
+				metrics.Latest.Format(time.RFC3339),
+				metrics.End.Format(time.RFC3339),
 			), text.WriteReplace())
 
 			codesText := ""

--- a/gui/drawer_test.go
+++ b/gui/drawer_test.go
@@ -236,9 +236,9 @@ Requests: 1
 Rate: 1.000000
 Throughput: 1.000000
 Success: 1.000000
-Earliest: 2009-11-10 23:00:00 +0000 UTC
-Latest: 2009-11-10 23:00:00 +0000 UTC
-End: 2009-11-10 23:00:00 +0000 UTC`, gomock.Any())
+Earliest: 2009-11-10T23:00:00Z
+Latest: 2009-11-10T23:00:00Z
+End: 2009-11-10T23:00:00Z`, gomock.Any())
 
 				return t
 			}(),


### PR DESCRIPTION
Sorry I took so long for this one :)

This closes #33 

edit: It looks like this, though (it has the T):
![image](https://user-images.githubusercontent.com/7342697/95153481-edf0ba80-0765-11eb-842d-6c8e1d7a3038.png)

