### PR TITLE
Support HTTP2 option

### DIFF
--- a/attacker/attacker.go
+++ b/attacker/attacker.go
@@ -79,6 +79,7 @@ func Attack(ctx context.Context, target string, resCh chan *Result, metricsCh ch
 			vegeta.MaxBody(opts.MaxBody),
 			vegeta.Connections(opts.Connections),
 			vegeta.KeepAlive(opts.KeepAlive),
+			vegeta.HTTP2(true),
 		)
 	}
 

--- a/attacker/attacker.go
+++ b/attacker/attacker.go
@@ -38,6 +38,7 @@ type Options struct {
 	MaxWorkers  uint64
 	KeepAlive   bool
 	Connections int
+	HTTP2       bool
 
 	Attacker Attacker
 }
@@ -79,7 +80,7 @@ func Attack(ctx context.Context, target string, resCh chan *Result, metricsCh ch
 			vegeta.MaxBody(opts.MaxBody),
 			vegeta.Connections(opts.Connections),
 			vegeta.KeepAlive(opts.KeepAlive),
-			vegeta.HTTP2(true),
+			vegeta.HTTP2(opts.HTTP2),
 		)
 	}
 

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ type cli struct {
 	workers     uint64
 	maxWorkers  uint64
 	connections int
+	http2       bool
 
 	debug     bool
 	version   bool
@@ -76,6 +77,7 @@ func parseFlags(stdout, stderr io.Writer) (*cli, error) {
 	flagSet.Uint64VarP(&c.workers, "workers", "w", attacker.DefaultWorkers, "Amount of initial workers to spawn.")
 	flagSet.Uint64VarP(&c.maxWorkers, "max-workers", "W", attacker.DefaultMaxWorkers, "Amount of maximum workers to spawn.")
 	flagSet.IntVarP(&c.connections, "connections", "c", attacker.DefaultConnections, "Amount of maximum open idle connections per target host")
+	flagSet.BoolVar(&c.http2, "http2", true, "Issue HTTP/2 requests to servers which support it. (default true)")
 	flagSet.Usage = c.usage
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		if !errors.Is(err, flag.ErrHelp) {
@@ -168,16 +170,18 @@ func (c *cli) makeOptions() (*attacker.Options, error) {
 	}
 
 	return &attacker.Options{
-		Rate:       c.rate,
-		Duration:   c.duration,
-		Timeout:    c.timeout,
-		Method:     c.method,
-		Body:       body,
-		MaxBody:    c.maxBody,
-		Header:     header,
-		KeepAlive:  c.keepAlive,
-		Workers:    c.workers,
-		MaxWorkers: c.maxWorkers,
+		Rate:        c.rate,
+		Duration:    c.duration,
+		Timeout:     c.timeout,
+		Method:      c.method,
+		Body:        body,
+		MaxBody:     c.maxBody,
+		Header:      header,
+		KeepAlive:   c.keepAlive,
+		Workers:     c.workers,
+		MaxWorkers:  c.maxWorkers,
+		Connections: c.connections,
+		HTTP2:       c.http2,
 	}, nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -58,6 +58,7 @@ func TestParseFlags(t *testing.T) {
 				connections: 10000,
 				stdout:      new(bytes.Buffer),
 				stderr:      new(bytes.Buffer),
+				http2:       true,
 			},
 			wantErr: false,
 		},
@@ -198,6 +199,31 @@ func TestMakeOptions(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "http2 given as false",
+			cli: &cli{
+				method:   "GET",
+				headers:  []string{"key:value"},
+				body:     "",
+				bodyFile: "testdata/body-1.json",
+				http2:    false,
+			},
+			want: &attacker.Options{
+				Rate:     0,
+				Duration: 0,
+				Timeout:  0,
+				Method:   "GET",
+				Body:     []byte(`{"foo": 1}`),
+				Header: http.Header{
+					"key": []string{"value"},
+				},
+				Workers:    0,
+				MaxWorkers: 0,
+				MaxBody:    0,
+				HTTP2:      false,
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR makes it possible to switch to send HTTP/2 requests when supported by the server.
Also found that `connections` is not passed to the `attacker.Options` struct while rebasing, fixed that as well :smiley: 

Added a flag `--http2` for switching to HTTP/2
```sh
mayadata:ali$ ./ali --help
Usage:
  ali [flags] <target URL>

Flags:
  -b, --body string         A request body to be sent.
  -B, --body-file string    The path to file whose content will be set as the http request body.
  -c, --connections int     Amount of maximum open idle connections per target host (default 10000
      --debug               Run in debug mode.
  -d, --duration duration   The amount of time to issue requests to the targets. Give 0s for an infinite attack. (default 10s)
  -H, --header strings      A request header to be sent. Can be used multiple times to send multiple headers.
      --http2               Issue HTTP/2 requests to servers which support it. (default true) (default true)
  -k, --keepalive           Use HTTP persistent connection. (default true)
  -M, --max-body int        Max bytes to capture from response bodies. Give -1 for no limit. (default -1)
  -W, --max-workers uint    Amount of maximum workers to spawn. (default 18446744073709551615)
  -m, --method string       An HTTP request method for each request. (default "GET")
  -r, --rate int            The request rate per second to issue against the targets. Give 0 then it will send requests as fast as possible. (default 50)
  -t, --timeout duration    The timeout for each request. 0s means to disable timeouts. (default 30s)
  -v, --version             Print the current version.
  -w, --workers uint        Amount of initial workers to spawn. (default 10)

Examples:
  ali --duration=10m --rate=100 http://host.xz

Author:
  Ryo Nakao <ryo@nakao.dev>
```  