### PR TITLE
Do not split --header flag into multiple values

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func parseFlags(stdout, stderr io.Writer) (*cli, error) {
 	flagSet.DurationVarP(&c.duration, "duration", "d", attacker.DefaultDuration, "The amount of time to issue requests to the targets. Give 0s for an infinite attack.")
 	flagSet.DurationVarP(&c.timeout, "timeout", "t", attacker.DefaultTimeout, "The timeout for each request. 0s means to disable timeouts.")
 	flagSet.StringVarP(&c.method, "method", "m", attacker.DefaultMethod, "An HTTP request method for each request.")
-	flagSet.StringSliceVarP(&c.headers, "header", "H", []string{}, "A request header to be sent. Can be used multiple times to send multiple headers.")
+	flagSet.StringArrayVarP(&c.headers, "header", "H", []string{}, "A request header to be sent. Can be used multiple times to send multiple headers.")
 	flagSet.StringVarP(&c.body, "body", "b", "", "A request body to be sent.")
 	flagSet.StringVarP(&c.bodyFile, "body-file", "B", "", "The path to file whose content will be set as the http request body.")
 	flagSet.Int64VarP(&c.maxBody, "max-body", "M", attacker.DefaultMaxBody, "Max bytes to capture from response bodies. Give -1 for no limit.")


### PR DESCRIPTION
Replaces pflag.StringSliceVarP with pflag.StringArrayVarP and thus     
disallows multiple headers to be defined with a single flag.           
Compare https://pkg.go.dev/github.com/spf13/pflag#StringSliceVar       
for details.                                                           
                                                                       
The previous implementation did not allow header values to contain     
a comma, this change fixes that. 