### PR TITLE
Exclude build step for Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     - freebsd
     - darwin
     - linux
-    - windows
+      #- windows
   goarch:
     - amd64
     - arm
@@ -24,10 +24,6 @@ builds:
   env:
     - CGO_ENABLED=0
   ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
-
-archives:
-- replacements:
-    386: 32-bit
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
"nakabonne/tstorage" does depend on the mmap system call. The current version of tstorage doesn't support Windows. To pass the CI exclude Windows among the target platforms for now.