### PR TITLE
Workaround race contition in drawer.redrawMetrics()

### DIFF
--- a/gui/drawer.go
+++ b/gui/drawer.go
@@ -199,6 +199,7 @@ func (d *drawer) redrawMetrics(ctx context.Context) {
 			// taking the slice of keys and sorting them.
 			codesText := ""
 			var keys []string
+			d.mu.RLock()
 			for k := range m.StatusCodes {
 				keys = append(keys, k)
 			}
@@ -207,6 +208,7 @@ func (d *drawer) redrawMetrics(ctx context.Context) {
 				codesText += fmt.Sprintf(`%q: %d
 `, k, m.StatusCodes[k])
 			}
+			d.mu.RUnlock()
 			d.widgets.statusCodesText.Write(codesText, text.WriteReplace())
 
 			errorsText := ""

--- a/gui/keybinds.go
+++ b/gui/keybinds.go
@@ -55,7 +55,7 @@ func attack(ctx context.Context, d *drawer, a attacker.Attacker) {
 	go d.redrawCharts(child)
 	go d.redrawGauge(child, a.Duration())
 	go func() {
-		a.Attack(child, d.metricsCh) // this blocks until attack finishes
+		a.Attack(child, d.metricsCh, &d.mu) // this blocks until attack finishes
 		cancel()
 	}()
 }


### PR DESCRIPTION
This is my current workaround I am using for the issue #111 (fatal error: concurrent map iteration and map write) to guard against concurrent access to the shared map `StatusCodes` accross `ali` and its library [tsenart/vegeta](https://github.com/tsenart/vegeta)