### PR TITLE
README: add MacPorts install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Binary releases are available through [here](https://github.com/nakabonne/ali/re
 brew install nakabonne/ali/ali
 ```
 
+**Via MacPorts**
+
+```bash
+sudo port selfupdate
+sudo port install ali
+```
+
 **Via APT**
 
 ```bash


### PR DESCRIPTION
Add instructions for installing `ali` via [MacPorts](https://www.macports.org)